### PR TITLE
Fix type annotations in an example

### DIFF
--- a/mypyc/doc/using_type_annotations.rst
+++ b/mypyc/doc/using_type_annotations.rst
@@ -83,7 +83,7 @@ Consider this example:
 .. code-block::
 
    class Point:
-       def __init__(self, x: int, y: int) -> int:
+       def __init__(self, x: int, y: int) -> None:
            self.x = x
            self.y = y
 


### PR DESCRIPTION
Changed the return type annotation for `__init__` from `int` to `None`

### Description

In one of the examples in `mypyc`'s documentation, the constructor doesn't have a correct return type
```python
class Point:
    def __init__(self, x: int, y: int) -> int:
        ...
```

I have changed it to `None` (according to [`mypy`'s documentation](https://mypy.readthedocs.io/en/stable/class_basics.html#annotating-init-methods) for example)
## Test Plan

No particular test plan, it is a simple typo fix in the documentation.
